### PR TITLE
First stab at a 'we support ssl' statement

### DIFF
--- a/ssl.md
+++ b/ssl.md
@@ -1,0 +1,8 @@
+---
+order: 1000
+---
+# SSL Encryption
+
+We support the trend of [adopting SSL encryption](https://www.eff.org/https-everywhere/deploying-https) across the internet.
+
+New tools and sites that we develop will be compatible with systems that require SSL encryption. We will work with other technology staff at the Libraries to retrofit existing code as part of our regular maintenance work.


### PR DESCRIPTION
Would it be worthwhile for us to add some sort of statement like this to our documentation - less as a "how to" but as a statement of values and reminder to check this particular box?

Maybe this would be better framed as a "how we do what we do" page, perhaps...thoughts?