### PR TITLE
Update python section

### DIFF
--- a/python.md
+++ b/python.md
@@ -5,13 +5,13 @@ order: 1000
 
 ## Python Versions
 
-In most cases, we should have at least 3.4 available on local servers. Unless there's a specific reason to do so, there is no need to support Python 2.
+You should be using the most recent stable version. Don't use Python 2.
 
 ## Style and Coding Conventions
 
 In general, you should follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) and [PEP 257](https://www.python.org/dev/peps/pep-0257/). Unless otherwise stated here, assume those two guidelines are in effect. It is recommended to use [flake8](http://flake8.pycqa.org/en/latest/) during development and CI.
 
-Use [reST](http://docutils.sourceforge.net/rst.html) in your docstrings. In addition to a description of what a function does, you should document the parameters:
+If you are providing function docstrings, use [reST](http://docutils.sourceforge.net/rst.html). In addition to a description of what a function does, you should document the parameters:
 
 ```python
 def widgetize(widget):
@@ -26,14 +26,13 @@ def widgetize(widget):
   standardize(widget)
 ```
 
-If you are supporting Python 2.7 you should make sure the first line of all your files contains:
+## Dependencies
 
-```python
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
+Use [Pipenv](https://pipenv.readthedocs.io/en/latest/) to manage dependencies. If there's some reason you need to support pip, then you should still manage dependencies with pipenv, but generate your `requirements.txt` file as needed with:
+
 ```
-
-If you are only targeting Python 3, this is not necessary.
+$ pipenv lock -r
+```
 
 ## Project Documentation
 
@@ -41,4 +40,4 @@ Use [Sphinx](http://sphinx-doc.org/) for generating project documentation.
 
 ## Testing
 
-Use [tox](https://tox.readthedocs.org/en/latest/). Keep any test-specific dependencies, i.e. unittest2, requests_mock, etc., out of your `requirements.txt` file. Those should be specified in your `tox.ini` where necessary.
+Since we no longer have to support both Python 2 and 3 there's less need for [tox](https://tox.readthedocs.org/en/latest/), though it can still be useful. Unless you are using something like Django that comes with its own testing framework, use [pytest](https://docs.pytest.org).


### PR DESCRIPTION
The main changes are to specifically state that we no longer use Python
2, and to switch dependency management from pip to pipenv.