### PR TITLE
Adds initial pass at Pantheon workflow documentation

### DIFF
--- a/pantheon.md
+++ b/pantheon.md
@@ -1,0 +1,17 @@
+---
+order: 1000
+---
+### Pantheon
+
+The MIT Libraries have made the choice to migrate many PHP-based websites to the [Pantheon](https://pantheon.io/) platform.
+
+#### Preferred Tooling and Workflow
+
+There are a variety of processes and tools that can be used to build on Pantheon. In order to prevent confusion and conflicting processes, we recommend that sites be built along the lines of the [Build Tools documentation](https://pantheon.io/docs/guides/build-tools/), which includes the following tooling:
+
+* GitHub
+* CircleCI
+* Composer
+* Pantheon Multidev
+
+In cases where this workflow is not feasible - primarily when migrating an existing website for which redevelopment is not possible - an FTP-based workflow that emphasizes the Pantheon dashboard in a web browser is also acceptable.


### PR DESCRIPTION
After losing too much time this morning trying to sort through which of the various tutorials and explanations was most relevant for a quick site build-out on Pantheon, I put this quick page together to link to the workflow that most resembles what I see from other platforms (specifically the Heroku workflow).