### PR TITLE
Adds link to ATIC, two manual-use a11y tools

### DIFF
--- a/a11y.md
+++ b/a11y.md
@@ -19,9 +19,10 @@ order: 1000
   early in the project.
 - Part of that plan will likely be to schedule an internal review with UX
   towards the end of the project.
-- Most projects should, coordinated through UX, schedule a formal review by MIT
-  Assistive Technology Information Center (ATIC) towards the end of the project.
-  The process and expectations for this should be discussed during the initial
+- Most projects should, coordinated through UX, schedule a formal review by [MIT
+  Assistive Technology Information Center
+  (ATIC)](http://studentlife.mit.edu/atic/) towards the end of the project. The
+  process and expectations for this should be discussed during the initial
   accessibility plan review.
 - Use valid html 5 and our [style guide](/mitlib-style) to start out with a
   great baseline for accessible websites.
@@ -44,6 +45,15 @@ order: 1000
 - All of our public GitHub repos are set to automatically check via
   [AccessLint](https://www.accesslint.com), which is great for what it is
   but is _not_ a comprehensive Accessibility Plan.
+
+#### Manual testing
+
+- The [Web Accessibility Evaluation Tool (WAVE)](https://wave.webaim.org/) is
+  useful for checking single web pages. It can be installed as a browser
+  extension for either Chrome or Firefox.
+- The [Accessible Name & Description Inspector (ANDI)
+  tool](https://www.ssa.gov/accessibility/andi/help/install.html) is a
+  Javascript tool to evaluate a loaded webpage.
 
 #### Resources
 


### PR DESCRIPTION
Our most recent round of accessibility-related changes to the parent theme resulted in remembering that we should add tools like WAVE and ANDI to our resources here (I've used WAVE before, but ANDI was new to me).

This is adding them to our page, as well as a link to the ATIC website.