### PR TITLE
Updates deploy instructions for use on our EC2 infrastructure

### DIFF
--- a/wordpress.md
+++ b/wordpress.md
@@ -11,12 +11,12 @@ Libraries, and forms the majority of [libraries.mit.edu](https://libraries.mit.e
 
 ##### Local deployments
 
-WordPress is used on locally-managed VMs that are administered by the
+WordPress is used on EC2 instance VMs that are administered by the
 Enterprise Services team. The Wordpress installation can be found at the
-Apache site root, which is usually:
+Apache site root, which is:
 
 ```
-/var/www/[hostname]/htdocs/
+/var/www/html/htdocs/
 ```
 
 Other applications can also be found under `htdocs/`, including a number of
@@ -113,11 +113,14 @@ git clone git@github.com:MITLibraries/wp-plugin-template.git ~/deploy/wp-plugin-
 
 ```
 cd ~/deploy/wp-plugin-template
+scl enable rh-nodejs8 /bin/bash
 npm install
 grunt
 ```
 
-3. Run the relevant deploy script, passing the project name as arguments
+3. Run the relevant deploy script, passing the project name as arguments. If
+you have not placed the deploy script into your deploy directory already, you
+can symlink it from `/usr/local/scripts/`.
 
 ```
 cd ~/deploy/


### PR DESCRIPTION
It looks like I never updated our WordPress instructions to include the note about needing the Node software collection if you're running grunt (which will be needed for theme work).

This tries to add that command in the relevant location.

I'll tag @JPrevost for a code review - doing the deploy for the parent theme for this a11y work should give an opportunity to make sure I'm not forgetting any steps here.